### PR TITLE
improve cli output and command parsing

### DIFF
--- a/cli/command_wrappers.go
+++ b/cli/command_wrappers.go
@@ -1,0 +1,27 @@
+package cli
+
+import (
+	"fmt"
+
+	"github.com/rokka-io/rokka-go/rokka"
+)
+
+func getStackoptions(c *rokka.Client, _ map[string]string, _ map[string]string) error {
+	res, err := c.GetStackoptions()
+	if err != nil {
+		return err
+	}
+	fmt.Println(PrettyJSON(res))
+
+	return nil
+}
+
+func getOrganization(c *rokka.Client, args map[string]string, _ map[string]string) error {
+	res, err := c.GetOrganization(args["name"])
+	if err != nil {
+		return err
+	}
+	fmt.Println(PrettyJSON(res))
+
+	return nil
+}

--- a/cli/commands.go
+++ b/cli/commands.go
@@ -8,9 +8,15 @@ import (
 	"github.com/rokka-io/rokka-go/rokka"
 )
 
+type UnknownCommandError string
+
+func (e UnknownCommandError) Error() string {
+	return string(e)
+}
+
 type Command struct {
-	args        []string
-	description string
+	Args        []string
+	Description string
 	fn          func(*rokka.Client)
 }
 
@@ -29,17 +35,16 @@ func GetCommands() []Command {
 	return commands
 }
 
-func ExecCommand(c *rokka.Client, args []string) {
+func ExecCommand(c *rokka.Client, args []string) error {
+	command := strings.Join(args, " ")
+
 	for _, v := range commands {
 		// TODO: improve this hacky line
-		if strings.Join(v.args, " ") == strings.Join(args, " ") {
+		if strings.Join(v.Args, " ") == command {
 			v.fn(c)
-			return
+			return nil
 		}
 	}
-	fmt.Println("Action not found")
-	fmt.Println("Available actions:")
-	for _, c := range commands {
-		fmt.Printf("\t%s - %s\n", strings.Join(c.args, " "), c.description)
-	}
+
+	return UnknownCommandError("Unknown command \"" + command + "\"")
 }

--- a/cli/commands.go
+++ b/cli/commands.go
@@ -2,12 +2,17 @@ package cli
 
 import (
 	"fmt"
-	"os"
 	"regexp"
 	"strings"
 
 	"github.com/rokka-io/rokka-go/rokka"
 )
+
+var positionalArgsRegexp *regexp.Regexp
+
+func init() {
+	positionalArgsRegexp = regexp.MustCompile("^<(.*)>$")
+}
 
 type UnknownCommandError string
 
@@ -18,73 +23,75 @@ func (e UnknownCommandError) Error() string {
 type Command struct {
 	Args        []string
 	Description string
-	fn          func(*rokka.Client, []string, map[string]string)
+	fn          func(*rokka.Client, map[string]string, map[string]string) error
 }
 
-var commands = []Command{
-	Command{[]string{"stackoptions", "list"}, "Show default stack options", func(c *rokka.Client, _ []string, _ map[string]string) {
+var Commands = []Command{
+	Command{[]string{"stackoptions", "list"}, "Show default stack options", func(c *rokka.Client, _ map[string]string, _ map[string]string) error {
 		res, err := c.GetStackoptions()
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "Error getting stack options: %s", err)
-			os.Exit(1)
+			return err
 		}
-		PrettyPrintJSON(res)
-	}},
-	Command{[]string{"organizations", "get", "<name>"}, "Get details of an organization", func(c *rokka.Client, args []string, _ map[string]string) {
-		res, err := c.GetOrganization(args[0])
-		if err != nil {
-			fmt.Fprintf(os.Stderr, "Error getting organization: %s", err)
-			os.Exit(1)
-		}
-		PrettyPrintJSON(res)
-	}},
-}
+		fmt.Println(PrettyJSON(res))
 
-func GetCommands() []Command {
-	return commands
+		return nil
+	}},
+	Command{[]string{"organizations", "get", "<name>"}, "Get details of an organization", func(c *rokka.Client, args map[string]string, _ map[string]string) error {
+		res, err := c.GetOrganization(args["name"])
+		if err != nil {
+			return err
+		}
+		fmt.Println(PrettyJSON(res))
+
+		return nil
+	}},
 }
 
 func ExecCommand(cl *rokka.Client, userArgs []string) error {
-	for _, c := range commands {
-		positionalArgs := []string{}
+	hasMatch := false
 
-		if len(userArgs) < len(c.Args) {
+	for _, c := range Commands {
+		commandArgsCount := len(c.Args)
+
+		if len(userArgs) < commandArgsCount {
 			continue
 		}
 
+		positionalArgs := make(map[string]string)
+
 		for i, arg := range c.Args {
 			// check whether this is a positional argument ("<arg>")
-			isPositionalArg, err := regexp.MatchString("^<.*>", arg)
-			if err != nil {
-				return err
-			}
+			positionalMatch := positionalArgsRegexp.FindString(arg)
 
-			if isPositionalArg {
-				positionalArgs = append(positionalArgs, userArgs[i])
+			if positionalMatch != "" {
+				positionalArgs[positionalMatch] = userArgs[i]
 			} else if arg != userArgs[i] {
 				// user provided argument doesn't match
 				break
 			}
 
 			// we reached the end
-			if len(c.Args) == i+1 {
-				options := map[string]string{}
+			if commandArgsCount == i+1 {
+				hasMatch = true
+			}
+		}
 
-				// parse rest into options ("key=value")
-				if len(userArgs) >= i {
-					for _, option := range userArgs[i:] {
-						split := strings.Split(option, "=")
-						if len(split) == 2 && split[0] != "" && split[1] != "" {
-							options[split[0]] = split[1]
-						}
+		if hasMatch {
+			options := map[string]string{}
+
+			// parse rest into options ("key=value")
+			if len(userArgs) > commandArgsCount {
+				for _, option := range userArgs[commandArgsCount-1:] {
+					split := strings.Split(option, "=")
+					if len(split) == 2 && split[0] != "" && split[1] != "" {
+						options[split[0]] = split[1]
 					}
 				}
-
-				c.fn(cl, positionalArgs, options)
-				return nil
 			}
+
+			return c.fn(cl, positionalArgs, options)
 		}
 	}
 
-	return UnknownCommandError("Unknown command \"" + strings.Join(userArgs, " ") + "\"")
+	return UnknownCommandError(fmt.Sprintf(`Unknown command "%s"`, strings.Join(userArgs, " ")))
 }

--- a/cli/commands.go
+++ b/cli/commands.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"fmt"
 	"os"
+	"regexp"
 	"strings"
 
 	"github.com/rokka-io/rokka-go/rokka"
@@ -17,14 +18,22 @@ func (e UnknownCommandError) Error() string {
 type Command struct {
 	Args        []string
 	Description string
-	fn          func(*rokka.Client)
+	fn          func(*rokka.Client, []string)
 }
 
 var commands = []Command{
-	Command{[]string{"stackoptions", "list"}, "Show default stack options", func(c *rokka.Client) {
+	Command{[]string{"stackoptions", "list"}, "Show default stack options", func(c *rokka.Client, _ []string) {
 		res, err := c.GetStackoptions()
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "Error getting stack options: %s", err)
+			os.Exit(1)
+		}
+		PrettyPrintJSON(res)
+	}},
+	Command{[]string{"organizations", "get", "<name>"}, "Get details of an organization", func(c *rokka.Client, options []string) {
+		res, err := c.GetOrganization(options[0])
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error getting organization: %s", err)
 			os.Exit(1)
 		}
 		PrettyPrintJSON(res)
@@ -35,16 +44,32 @@ func GetCommands() []Command {
 	return commands
 }
 
-func ExecCommand(c *rokka.Client, args []string) error {
-	command := strings.Join(args, " ")
+func ExecCommand(cl *rokka.Client, userArgs []string) error {
+	for _, c := range commands {
+		options := []string{}
 
-	for _, v := range commands {
-		// TODO: improve this hacky line
-		if strings.Join(v.Args, " ") == command {
-			v.fn(c)
-			return nil
+		for i, arg := range c.Args {
+			if len(userArgs) < i+1 {
+				break
+			}
+
+			isOption, err := regexp.MatchString("^<.*>", arg)
+			if err != nil {
+				return err
+			}
+
+			if isOption {
+				options = append(options, userArgs[i])
+			} else if arg != userArgs[i] {
+				break
+			}
+
+			if len(c.Args) == i+1 {
+				c.fn(cl, options)
+				return nil
+			}
 		}
 	}
 
-	return UnknownCommandError("Unknown command \"" + command + "\"")
+	return UnknownCommandError("Unknown command \"" + strings.Join(userArgs, " ") + "\"")
 }

--- a/cli/config.go
+++ b/cli/config.go
@@ -2,14 +2,15 @@ package cli
 
 import (
 	"encoding/json"
+	"io/ioutil"
 	"os"
 	"os/user"
-	"path"	
-	"io/ioutil"
+	"path"
 )
 
 type Config struct {
-	APIKey string `json:"apiKey"`
+	APIKey       string `json:"apiKey"`
+	APIAddress   string `json:"apiAddress"`
 	Organization string `json:"organization"`
 }
 

--- a/cli/utils.go
+++ b/cli/utils.go
@@ -1,17 +1,29 @@
 package cli
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"os"
 )
 
-func PrettyPrintJSON(data interface{}) {
-	s, err := json.MarshalIndent(data, "", "  ")
+func PrettyJSON(data interface{}) string {
+	var s []byte
+	var err error
+
+	switch data := data.(type) {
+	case []byte:
+		var pretty bytes.Buffer
+		err = json.Indent(&pretty, data, "", "  ")
+		s = pretty.Bytes()
+	default:
+		s, err = json.MarshalIndent(data, "", "  ")
+	}
+
 	if err != nil {
-		fmt.Printf("Error marshalling JSON: %s\n", err)
+		fmt.Fprintf(os.Stderr, "Error marshalling JSON: %s\n", err)
 		os.Exit(1)
 	}
 
-	fmt.Println(string(s))
+	return string(s)
 }

--- a/cmd/rokka/main.go
+++ b/cmd/rokka/main.go
@@ -11,9 +11,11 @@ import (
 )
 
 var apiKey string
+var apiAddress string
 
 func init() {
-	flag.StringVar(&apiKey, "apiKey", "", "Optional API Key")
+	flag.StringVar(&apiKey, "apiKey", "", "Optional API key")
+	flag.StringVar(&apiAddress, "apiAddress", "", "Optional API address")
 
 	flag.Usage = func() {
 		fmt.Fprintf(os.Stderr, "Usage: %s <command>\n\n", os.Args[0])
@@ -44,8 +46,13 @@ func main() {
 		cfg.APIKey = apiKey
 	}
 
+	if len(apiAddress) != 0 {
+		cfg.APIAddress = apiAddress
+	}
+
 	cl := rokka.NewClient(&rokka.Config{
-		APIKey: cfg.APIKey,
+		APIKey:     cfg.APIKey,
+		APIAddress: cfg.APIAddress,
 	})
 
 	err = cli.ExecCommand(cl, args)
@@ -71,6 +78,10 @@ func main() {
 
 func printCommands(f *os.File) {
 	for _, c := range cli.Commands {
-		fmt.Fprintf(f, "  %s\t%s\n", strings.Join(c.Args, " "), c.Description)
+		options := ""
+		if len(c.Options) != 0 {
+			options = fmt.Sprintf("\t (Options: %s)", strings.Join(c.Options, ", "))
+		}
+		fmt.Fprintf(f, "  %s\t%s%s\n", strings.Join(c.Args, " "), c.Description, options)
 	}
 }

--- a/cmd/rokka/main.go
+++ b/cmd/rokka/main.go
@@ -59,11 +59,11 @@ func main() {
 		fmt.Fprintf(os.Stderr, "Error: %v\n\n", err)
 		fmt.Fprint(os.Stderr, "Commands:\n")
 		printCommands(os.Stderr)
-		os.Exit(1)
 	default:
 		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
-		os.Exit(1)
 	}
+
+	os.Exit(1)
 }
 
 func printCommands(f *os.File) {

--- a/cmd/rokka/main.go
+++ b/cmd/rokka/main.go
@@ -54,11 +54,14 @@ func main() {
 		os.Exit(0)
 	}
 
-	switch err.(type) {
+	switch err := err.(type) {
 	case cli.UnknownCommandError:
 		fmt.Fprintf(os.Stderr, "Error: %v\n\n", err)
 		fmt.Fprint(os.Stderr, "Commands:\n")
 		printCommands(os.Stderr)
+	case rokka.StatusCodeError:
+		fmt.Fprintf(os.Stderr, "Error: %v\n\n", err)
+		fmt.Fprintf(os.Stderr, "%s\n", cli.PrettyJSON(err.Body))
 	default:
 		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
 	}
@@ -67,7 +70,7 @@ func main() {
 }
 
 func printCommands(f *os.File) {
-	for _, c := range cli.GetCommands() {
+	for _, c := range cli.Commands {
 		fmt.Fprintf(f, "  %s\t%s\n", strings.Join(c.Args, " "), c.Description)
 	}
 }

--- a/rokka/client.go
+++ b/rokka/client.go
@@ -75,6 +75,16 @@ func (c *Client) Call(req *http.Request, v interface{}) error {
 	return decoder.Decode(&v)
 }
 
-func (c *Client) NewRequest(method, path string, body io.Reader) (*http.Request, error) {
-	return http.NewRequest(method, c.config.APIAddress+path, body)
+func (c *Client) NewRequest(method, path string, body io.Reader, query map[string]string) (*http.Request, error) {
+	req, err := http.NewRequest(method, c.config.APIAddress+path, body)
+
+	if query != nil {
+		q := req.URL.Query()
+		for k, v := range query {
+			q.Add(k, v)
+		}
+		req.URL.RawQuery = q.Encode()
+	}
+
+	return req, err
 }

--- a/rokka/fixtures/GetOrganization.json
+++ b/rokka/fixtures/GetOrganization.json
@@ -1,0 +1,1 @@
+{"id":"8c0cbde4-ba62-11e7-abc4-cec278b6b50a","display_name":"Dev Environment","name":"test","billing_email":"info@example.com","limit":{"space_in_bytes":2147483648,"traffic_in_bytes":5368709120}}

--- a/rokka/organizations.go
+++ b/rokka/organizations.go
@@ -1,0 +1,15 @@
+package rokka
+
+type OrganizationResponse struct{}
+
+func (c *Client) GetOrganization(name string) (OrganizationResponse, error) {
+	result := OrganizationResponse{}
+
+	req, err := c.NewRequest("GET", "/organizations/"+name, nil)
+	if err != nil {
+		return result, err
+	}
+
+	err = c.Call(req, &result)
+	return result, err
+}

--- a/rokka/organizations.go
+++ b/rokka/organizations.go
@@ -5,7 +5,7 @@ type OrganizationResponse struct{}
 func (c *Client) GetOrganization(name string) (OrganizationResponse, error) {
 	result := OrganizationResponse{}
 
-	req, err := c.NewRequest("GET", "/organizations/"+name, nil)
+	req, err := c.NewRequest("GET", "/organizations/"+name, nil, nil)
 	if err != nil {
 		return result, err
 	}

--- a/rokka/organizations.go
+++ b/rokka/organizations.go
@@ -1,6 +1,15 @@
 package rokka
 
-type OrganizationResponse struct{}
+type OrganizationResponse struct {
+	ID           string `json:"id"`
+	DisplayName  string `json:"display_name"`
+	Name         string `json:"name"`
+	BillingEmail string `json:"billing_email"`
+	Limit        struct {
+		SpaceInBytes   *int `json:"space_in_bytes"`
+		TrafficInBytes *int `json:"traffic_in_bytes"`
+	} `json:"limit"`
+}
 
 func (c *Client) GetOrganization(name string) (OrganizationResponse, error) {
 	result := OrganizationResponse{}

--- a/rokka/organizations_test.go
+++ b/rokka/organizations_test.go
@@ -1,0 +1,22 @@
+package rokka
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/rokka-io/rokka-go/test"
+)
+
+func TestGetOrganization(t *testing.T) {
+	ts := test.NewMockAPI("./fixtures/GetOrganization.json", http.StatusOK)
+	defer ts.Close()
+
+	c := NewClient(&Config{APIAddress: ts.URL})
+
+	res, err := c.GetOrganization("test")
+	if err != nil {
+		t.Error(err)
+	}
+
+	t.Log(res)
+}

--- a/rokka/stackoptions.go
+++ b/rokka/stackoptions.go
@@ -1,16 +1,14 @@
 package rokka
 
-type Property struct {
-	Type      string      `json:"type"`
-	MinLength *int        `json:"minLength,omitempty"`
-	Values    []string    `json:"values,omitempty"`
-	Default   interface{} `json:"default,omitempty"`
-	Minimum   *int        `json:"minimum,omitempty"`
-	Maximum   *int        `json:"maximum,omitempty"`
-}
-
 type StackoptionsResponse struct {
-	Properties map[string]Property `json:"properties"`
+	Properties map[string]struct {
+		Type      string      `json:"type"`
+		MinLength *int        `json:"minLength,omitempty"`
+		Values    []string    `json:"values,omitempty"`
+		Default   interface{} `json:"default,omitempty"`
+		Minimum   *int        `json:"minimum,omitempty"`
+		Maximum   *int        `json:"maximum,omitempty"`
+	} `json:"properties"`
 }
 
 func (c *Client) GetStackoptions() (StackoptionsResponse, error) {

--- a/rokka/stackoptions.go
+++ b/rokka/stackoptions.go
@@ -16,7 +16,7 @@ type StackoptionsResponse struct {
 func (c *Client) GetStackoptions() (StackoptionsResponse, error) {
 	result := StackoptionsResponse{}
 
-	req, err := c.NewRequest("GET", "/stackoptions", nil)
+	req, err := c.NewRequest("GET", "/stackoptions", nil, nil)
 	if err != nil {
 		return result, err
 	}

--- a/rokka/stackoptions_test.go
+++ b/rokka/stackoptions_test.go
@@ -1,21 +1,22 @@
 package rokka
 
 import (
-	"testing"
-	"github.com/rokka-io/rokka-go/test"
 	"net/http"
+	"testing"
+
+	"github.com/rokka-io/rokka-go/test"
 )
 
 func TestGetStackoptions(t *testing.T) {
 	ts := test.NewMockAPI("./fixtures/GetStackoptions.json", http.StatusOK)
-	defer ts.Close()	
-	
+	defer ts.Close()
+
 	c := NewClient(&Config{APIAddress: ts.URL})
 
-	res, err := c.GetStackoptions()	
+	res, err := c.GetStackoptions()
 	if err != nil {
 		t.Error(err)
 	}
-	
+
 	t.Log(res)
 }


### PR DESCRIPTION
With the current parsing logic it would be possible to make a [call for searching source images](https://rokka.io/documentation/references/searching-images.html) like this:
```
$ rokka sourceimages list myorganization limit=100 offset=200
```

In the example above, "myorganization" is a required argument (typically sent as part of the path), whereas "limit" and "offset" are optional (typically sent as query params).

**TODO**
- [x] Specify API response error struct for Rokka
- [x] Specify options for each command (CLI and lib)
- [x] Write tests for organizations API